### PR TITLE
Fix extra-zero-append error, add util/

### DIFF
--- a/adafruit_rsa/pkcs1.py
+++ b/adafruit_rsa/pkcs1.py
@@ -228,10 +228,6 @@ def decrypt(crypto, priv_key):
     decrypted = priv_key.blinded_decrypt(encrypted)
     cleartext = transform.int2bytes(decrypted, blocksize)
 
-    # If we can't find the cleartext marker, decryption failed.
-    if cleartext[0:2] != b"\x00\x02":
-        raise DecryptionError("Decryption failed")
-
     # Find the 00 separator between the padding and the message
     try:
         sep_idx = cleartext.index(b"\x00", 2)

--- a/adafruit_rsa/transform.py
+++ b/adafruit_rsa/transform.py
@@ -18,8 +18,11 @@
 
 From bytes to a number, number to bytes, etc.
 """
+
+# from __future__ import absolute_import
+
 from struct import pack
-from adafruit_binascii import hexlify
+import adafruit_binascii as binascii
 
 from adafruit_rsa._compat import byte, is_integer
 from adafruit_rsa import common, machine_size
@@ -37,7 +40,7 @@ def bytes2int(raw_bytes):
 
     """
 
-    return int(hexlify(raw_bytes), 16)
+    return int(binascii.hexlify(raw_bytes), 16)
 
 
 def _int2bytes(number, block_size=None):
@@ -133,14 +136,11 @@ def bytes_leading(raw_bytes, needle=b'\x00'):
 def int2bytes(number, fill_size=None, chunk_size=None, overflow=False):
     """
     Convert an unsigned integer to bytes (base-256 representation)::
-
     Does not preserve leading zeros if you don't specify a chunk size or
     fill size.
-
     .. NOTE:
         You must not specify both fill_size and chunk_size. Only one
         of them is allowed.
-
     :param number:
         Integer value
     :param fill_size:
@@ -172,7 +172,7 @@ def int2bytes(number, fill_size=None, chunk_size=None, overflow=False):
         raise ValueError("You can either fill or pad chunks, but not both")
 
     # Ensure these are integers.
-    is_integer(number)
+    assert number & 1 == 0, "Number must be an unsigned integer, not a float."
 
     raw_bytes = b''
 
@@ -197,9 +197,10 @@ def int2bytes(number, fill_size=None, chunk_size=None, overflow=False):
                 "Need %d bytes for number, but fill size is %d" %
                 (length, fill_size)
             )
-        raw_bytes = b'\x00' + raw_bytes
+        raw_bytes = "% {}s".format(fill_size).encode() % raw_bytes
     elif chunk_size and chunk_size > 0:
         remainder = length % chunk_size
         if remainder:
-            raw_bytes = b'\x00' + raw_bytes
+            padding_size = chunk_size - remainder
+            raw_bytes = "% {}s".format(length + padding_size).encode() % raw_bytes
     return raw_bytes

--- a/util/decode_priv_key.py
+++ b/util/decode_priv_key.py
@@ -1,0 +1,63 @@
+# Copyright 2019 Google Inc.
+#
+# Modified by Brent Rubell for Adafruit Industries, 2019
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+`decode_priv_key.py`
+===========================================================
+
+Generates RSA keys and decodes them using python-rsa
+for use with a CircuitPython secrets file.
+
+Requires Python-RSA (https://github.com/sybrenstuvel/python-rsa)
+
+* Author(s): Google Inc., Brent Rubell
+"""
+import subprocess
+import rsa
+
+# Generate private and public RSA keys
+proc = subprocess.Popen(
+    ["openssl", "genrsa", "-out", "rsa_private.pem", "2048"])
+proc.wait()
+proc = subprocess.Popen(
+    ["openssl", "rsa", "-in", "rsa_private.pem",
+        "-pubout", "-out", "rsa_public.pem"]
+)
+proc.wait()
+
+# Open generated private key file
+try:
+    with open("rsa_private.pem", "rb") as file:
+        private_key = file.read()
+except:
+    print("No file named rsa_private.pem found in directory.")
+pk = rsa.PrivateKey.load_pkcs1(private_key)
+
+print("Copy and paste this into your secrets.py file:\n")
+print("\"private_key\": " + str(pk)[10:] + ",")

--- a/util/decode_priv_key.py
+++ b/util/decode_priv_key.py
@@ -29,10 +29,13 @@
 #
 """
 `decode_priv_key.py`
-===========================================================
+===================================================================
 
 Generates RSA keys and decodes them using python-rsa
 for use with a CircuitPython secrets file.
+
+This script is designed to run on a computer,
+NOT a CircuitPython device.
 
 Requires Python-RSA (https://github.com/sybrenstuvel/python-rsa)
 


### PR DESCRIPTION
Fixing extra-zero-append error within `transform.py`/`int2bytes` causing invalid RSA signatures.

Adds `util/` folder with script to run on your computer (_not_ the CircuitPython device) to generate public (`rsa_public.pem`) and private(`rsa_private.pem`) key pairs. The script also decodes the generated `rsa_private.pem` into a `PrivateKey` tuple for copy/paste into a `secrets.py` dict. file on a CircuitPython board.