### PR TITLE
Add appropriate __version__ and __repo__ 

### DIFF
--- a/adafruit_rsa/__init__.py
+++ b/adafruit_rsa/__init__.py
@@ -29,4 +29,6 @@ from adafruit_rsa.pkcs1 import encrypt, decrypt, sign, verify, DecryptionError, 
 
 __author__ = "Sybren Stuvel, Barry Mead and Yesudeep Mangalapilly"
 __date__ = "2018-09-16"
-__version__ = '4.0.0'
+# __version__ = '4.0.0'
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_RSA.git"

--- a/adafruit_rsa/_compat.py
+++ b/adafruit_rsa/_compat.py
@@ -19,6 +19,9 @@
 import sys
 from struct import pack
 
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_RSA.git"
+
 MAX_INT = sys.maxsize
 MAX_INT64 = (1 << 63) - 1
 MAX_INT32 = (1 << 31) - 1

--- a/adafruit_rsa/asn1.py
+++ b/adafruit_rsa/asn1.py
@@ -22,6 +22,8 @@ Not all ASN.1-handling code use these definitions, but when it does, they should
 # pylint: disable=no-name-in-module, too-few-public-methods
 from pyasn1.type import univ, namedtype, tag
 
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_RSA.git"
 
 class PubKeyHeader(univ.Sequence):
     """OpenSSL Public Key Header"""

--- a/adafruit_rsa/common.py
+++ b/adafruit_rsa/common.py
@@ -18,6 +18,9 @@
 # pylint: disable=redefined-builtin, invalid-name
 from adafruit_rsa._compat import zip
 
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_RSA.git"
+
 def bit_length(int_type):
     """Return the number of bits necessary to represent an integer in binary,
     excluding the sign and leading zeros"""

--- a/adafruit_rsa/core.py
+++ b/adafruit_rsa/core.py
@@ -23,6 +23,9 @@ mathematically on integers.
 # pylint: disable=invalid-name
 from adafruit_rsa._compat import is_integer
 
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_RSA.git"
+
 def fast_pow(x, e, m):
     """Performs fast modular exponentiation, saves RAM on small CPUs/micros.
     :param int x: Base

--- a/adafruit_rsa/key.py
+++ b/adafruit_rsa/key.py
@@ -40,6 +40,9 @@ import adafruit_rsa.common
 import adafruit_rsa.randnum
 import adafruit_rsa.core
 
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_RSA.git"
+
 # pylint: disable=invalid-name, useless-object-inheritance, redefined-builtin, no-name-in-module, too-few-public-methods
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)

--- a/adafruit_rsa/machine_size.py
+++ b/adafruit_rsa/machine_size.py
@@ -18,6 +18,9 @@
 
 import sys
 
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_RSA.git"
+
 MAX_INT = sys.maxsize
 MAX_INT64 = (1 << 63) - 1
 MAX_INT32 = (1 << 31) - 1

--- a/adafruit_rsa/pem.py
+++ b/adafruit_rsa/pem.py
@@ -19,6 +19,8 @@ from adafruit_binascii import a2b_base64, b2a_base64
 # pylint: disable=redefined-builtin
 from adafruit_rsa._compat import is_bytes, range
 
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_RSA.git"
 
 def _markers(pem_marker):
     """

--- a/adafruit_rsa/pkcs1.py
+++ b/adafruit_rsa/pkcs1.py
@@ -31,6 +31,9 @@ import os
 import adafruit_hashlib as hashlib
 from adafruit_rsa import common, transform, core
 
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_RSA.git"
+
 # ASN.1 codes that describe the hash algorithm used.
 HASH_ASN1 = {
     "MD5": b"\x30\x20\x30\x0c\x06\x08\x2a\x86\x48\x86\xf7\x0d\x02\x05\x05\x00\x04\x10",

--- a/adafruit_rsa/prime.py
+++ b/adafruit_rsa/prime.py
@@ -24,6 +24,9 @@ from adafruit_rsa._compat import range
 import adafruit_rsa.common
 import adafruit_rsa.randnum
 
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_RSA.git"
+
 __all__ = ['getprime', 'are_relatively_prime']
 
 

--- a/adafruit_rsa/randnum.py
+++ b/adafruit_rsa/randnum.py
@@ -23,6 +23,8 @@ import os
 from adafruit_rsa import common, transform
 from adafruit_rsa._compat import byte
 
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_RSA.git"
 
 def read_random_bits(nbits):
     """Reads 'nbits' random bits.

--- a/adafruit_rsa/transform.py
+++ b/adafruit_rsa/transform.py
@@ -27,6 +27,8 @@ import adafruit_binascii as binascii
 from adafruit_rsa._compat import byte, is_integer
 from adafruit_rsa import common, machine_size
 
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_RSA.git"
 
 def bytes2int(raw_bytes):
     """Converts a list of bytes or an 8-bit string to an integer.


### PR DESCRIPTION
Adding appropriate `__version__` and `__repo__` strings to `adafruit_rsa/*.py` files for CircuitPython consistency. 

`__version__` string reflecting the [python-rsa](https://github.com/sybrenstuvel/python-rsa) version in `__init__.py` commented out.