### PR TITLE
Add pyasn1 as dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,8 @@ This driver depends on:
 
 * `Adafruit CircuitPython <https://github.com/adafruit/circuitpython>`_
 * `Adafruit CircuitPython Logger Module <https://github.com/adafruit/Adafruit_CircuitPython_Logger>`_
+* `pyasn1 Library <https://github.com/etingof/pyasn1>`_ (some functionality)
+* CPython's ``rsa`` Library (some functionality)
 
 Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading

--- a/adafruit_rsa/asn1.py
+++ b/adafruit_rsa/asn1.py
@@ -9,7 +9,10 @@ Not all ASN.1-handling code use these definitions, but when it does, they should
 """
 
 # pylint: disable=no-name-in-module, too-few-public-methods
-from pyasn1.type import univ, namedtype, tag
+try:
+    from pyasn1.type import univ, namedtype, tag
+except ImportError as err:
+    raise ImportError("Usage of asn1.py requires pyasn1 library") from err
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_RSA.git"

--- a/adafruit_rsa/key.py
+++ b/adafruit_rsa/key.py
@@ -270,7 +270,13 @@ class PublicKey(AbstractKey):
             from pyasn1.codec.der import encoder
         except ImportError as err:
             raise ImportError("This functionality requires the  library") from err
-        from rsa.asn1 import AsnPubKey
+        try:
+            from rsa.asn1 import AsnPubKey
+        except ImportError as err:
+            raise ImportError(
+                "This functionality requres the CPython rsa library, "
+                "not available in CircuitPython"
+            ) from err
 
         # Create the ASN object
         asn_key = AsnPubKey()

--- a/adafruit_rsa/key.py
+++ b/adafruit_rsa/key.py
@@ -250,8 +250,11 @@ class PublicKey(AbstractKey):
 
         """
         # pylint: disable=import-outside-toplevel
-        from adafruit_rsa.tools.pyasn1.codec.der import decoder
-        from adafruit_rsa.asn1 import AsnPubKey
+        try:
+            from adafruit_rsa.tools.pyasn1.codec.der import decoder
+            from adafruit_rsa.asn1 import AsnPubKey
+        except ImportError as err:
+            raise ImportError("This functionality requires the pyasn1 library") from err
 
         (priv, _) = decoder.decode(keyfile, asn1Spec=AsnPubKey())
         return cls(n=int(priv["modulus"]), e=int(priv["publicExponent"]))
@@ -263,7 +266,10 @@ class PublicKey(AbstractKey):
         :rtype: bytes
         """
         # pylint: disable=import-outside-toplevel
-        from pyasn1.codec.der import encoder
+        try:
+            from pyasn1.codec.der import encoder
+        except ImportError as err:
+            raise ImportError("This functionality requires the  library") from err
         from rsa.asn1 import AsnPubKey
 
         # Create the ASN object
@@ -328,9 +334,12 @@ class PublicKey(AbstractKey):
 
         """
         # pylint: disable=import-outside-toplevel
-        from adafruit_rsa.asn1 import OpenSSLPubKey
-        from pyasn1.codec.der import decoder
-        from pyasn1.type import univ
+        try:
+            from adafruit_rsa.asn1 import OpenSSLPubKey
+            from pyasn1.codec.der import decoder
+            from pyasn1.type import univ
+        except ImportError as err:
+            raise ImportError("This functionality requires the pyasn1 library") from err
 
         (keyinfo, _) = decoder.decode(keyfile, asn1Spec=OpenSSLPubKey())
 
@@ -477,9 +486,12 @@ class PrivateKey(AbstractKey):
 
         """
 
-        from adafruit_rsa.tools.pyasn1.codec.der import (  # pylint: disable=import-outside-toplevel
-            decoder,
-        )
+        try:
+            from adafruit_rsa.tools.pyasn1.codec.der import (  # pylint: disable=import-outside-toplevel
+                decoder,
+            )
+        except ImportError as err:
+            raise ImportError("This functionality requires the pyasn1 library") from err
 
         (priv, _) = decoder.decode(keyfile)
 
@@ -521,8 +533,11 @@ class PrivateKey(AbstractKey):
         :rtype: bytes
         """
         # pylint: disable=import-outside-toplevel
-        from pyasn1.type import univ, namedtype
-        from pyasn1.codec.der import encoder
+        try:
+            from pyasn1.type import univ, namedtype
+            from pyasn1.codec.der import encoder
+        except ImportError as err:
+            raise ImportError("This functionality requires the pyasn1 library") from err
 
         class AsnPrivKey(univ.Sequence):
             """Creates PKCS#1 DER Formatted AsnPrivKey"""


### PR DESCRIPTION
One of the changes from #22 that is needed a little more urgently, given that it is an unmarked and unincluded dependency for this library.  Figured it was better to separate it out so it can be applied faster.