### PR TITLE
Add StreamHandler to logger, add missing dependencies

### DIFF
--- a/adafruit_rsa/key.py
+++ b/adafruit_rsa/key.py
@@ -49,6 +49,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_RSA.git"
 
 # pylint: disable=invalid-name, useless-object-inheritance, redefined-builtin, no-name-in-module, too-few-public-methods
 log = logging.getLogger(__name__)
+log.addHandler(logging.StreamHandler())
 log.setLevel(logging.INFO)
 
 DEFAULT_EXPONENT = 65537

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@
 # SPDX-License-Identifier: Unlicense
 
 Adafruit-Blinka>=7.0.0
+adafruit-circuitpython-logging>=4.0.0
 pyasn1

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,11 @@ setup(
     # Author details
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
-    install_requires=["Adafruit-Blinka>=7.0.0"],
+    install_requires=[
+        "Adafruit-Blinka>=7.0.0",
+        "adafruit-circuitpython-logging>=4.0.0",
+        "pyasn1",
+    ],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Resolves #33  by adding a `StreamHandler` to the `Logger`, and pins the minimum version of `adafruit_logging`.  Also adds missing dependencies.