### PR TITLE
Fix setup.py to use "packages"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,5 +55,5 @@ setup(
     # simple. Or you can use find_packages().
     # TODO: IF LIBRARY FILES ARE A PACKAGE FOLDER,
     #       CHANGE `py_modules=['...']` TO `packages=['...']`
-    py_modules=["adafruit_rsa"],
+    packages=["adafruit_rsa"],
 )


### PR DESCRIPTION
Noticed while I was testing out `pyproject.toml` in another library that depends on this one.  I think this is the cause of the install error I'm facing.