### PR TITLE
Fix pylint errors

### DIFF
--- a/adafruit_rsa/key.py
+++ b/adafruit_rsa/key.py
@@ -58,8 +58,6 @@ DEFAULT_EXPONENT = 65537
 class AbstractKey(object):
     """Abstract superclass for private and public keys."""
 
-    __slots__ = ("n", "e")
-
     def __init__(self, n: int, e: int) -> None:
         self.n = n
         self.e = e

--- a/adafruit_rsa/pkcs1.py
+++ b/adafruit_rsa/pkcs1.py
@@ -44,7 +44,6 @@ try:
 
         def read(self, blocksize: int) -> Union[bytes, str]:
             """A method that reads a given number of bytes or chracters"""
-            ...
 
 except ImportError:
     pass

--- a/examples/rsa_tests.py
+++ b/examples/rsa_tests.py
@@ -93,11 +93,10 @@ all_tests = [
 
 # Run adafruit_rsa tests
 start_time = time.monotonic()
-# pylint: disable=consider-using-enumerate
-for test_num, test_name in enumerate(all_tests, start=0):
+for test_name in all_tests:
     # for i in range(0, len(all_tests)):
     print("Testing: {}".format(test_name))
-    all_tests[test_num]()
+    test_name()
     print("OK!")
 print(
     "Ran {} tests in {} seconds".format(len(all_tests), time.monotonic() - start_time)


### PR DESCRIPTION
Fixes the following `pylint` errors:

```
 ************* Module adafruit_rsa.pkcs1
Error: adafruit_rsa/pkcs1.py:47:12: W2301: Unnecessary ellipsis constant (unnecessary-ellipsis)
************* Module adafruit_rsa.key
Error: adafruit_rsa/key.py:211:16: W0244: Redefined slots ['n', 'e'] in subclass (redefined-slots-in-subclass)
Error: adafruit_rsa/key.py:390:16: W0244: Redefined slots ['n', 'e'] in subclass (redefined-slots-in-subclass)

-----------------------------------
Your code has been rated at 9.96/10

Error: pylint (example code)....................................................Failed
- hook id: pylint
- exit code: 8

************* Module rsa_tests
Error: examples/rsa_tests.py:100:4: R1736: Unnecessary list index lookup, use 'test_name' instead (unnecessary-list-index-lookup)
```
