### PR TITLE
generate json keys example

### DIFF
--- a/examples/rsa_generate_json_keys.py
+++ b/examples/rsa_generate_json_keys.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2024 Tim Cocks
+# SPDX-License-Identifier: MIT
+"""
+This script can be used to generate a new key pair and output them as JSON.
+You can copy the JSON from serial console and paste it into a new file
+on the device and then use it with the rsa_json_keys.py example.
+"""
+import json
+import adafruit_rsa
+
+
+# Create a keypair
+print("Generating keypair...")
+(public_key, private_key) = adafruit_rsa.newkeys(512)
+
+
+print("public json:")
+print("-------------------------------")
+public_obj = {"public_key_arguments": [public_key.n, public_key.e]}
+print(json.dumps(public_obj))
+print("-------------------------------")
+
+
+print("private json:")
+print("-------------------------------")
+private_obj = {
+    "private_key_arguments": [
+        private_key.n,
+        private_key.e,
+        private_key.d,
+        private_key.p,
+        private_key.q,
+    ]
+}
+print(json.dumps(private_obj))
+print("-------------------------------")


### PR DESCRIPTION
Adding another example that can be used to generate the JSON keys used by: https://github.com/adafruit/Adafruit_CircuitPython_RSA/blob/main/examples/rsa_json_keys.py